### PR TITLE
Improved current format of binary data for serialization / deserialization values and other fixes.

### DIFF
--- a/src/BinaryFormatter/BinaryConverter.cs
+++ b/src/BinaryFormatter/BinaryConverter.cs
@@ -46,11 +46,6 @@ namespace BinaryFormatter
             offset += typeInfoSize;
 
             BaseTypeConverter converter = ConvertersSelector.SelectConverter(sourceType);
-            if (converter == null)
-            {
-                converter = ConvertersSelector.ForSerializedType(SerializedType.CustomObject);
-            }
-
             if (converter is IEnumerableConverter)
             {
                 var prepearedData = converter.DeserializeToObject(stream) as IEnumerable;

--- a/src/BinaryFormatter/BinaryConverter.cs
+++ b/src/BinaryFormatter/BinaryConverter.cs
@@ -36,14 +36,18 @@ namespace BinaryFormatter
                 object NullObject = null;
                 return (T)NullObject;
             }
-
-            int typeInfoSize = BitConverter.ToInt32(stream, offset);
-            offset += sizeof(int);
-            byte[] typeInfo = new byte[typeInfoSize];
-            Array.Copy(stream, offset, typeInfo, 0, typeInfo.Length);
-            string typeFullName = Encoding.UTF8.GetString(typeInfo, 0, typeInfo.Length);
-            Type sourceType = System.Type.GetType(typeFullName);
-            offset += typeInfoSize;
+            
+            Type sourceType = deserializedType.GetBaseType();
+            if (sourceType == null)
+            {
+                int typeInfoSize = BitConverter.ToInt32(stream, offset);
+                offset += sizeof(int);
+                byte[] typeInfo = new byte[typeInfoSize];
+                Array.Copy(stream, offset, typeInfo, 0, typeInfo.Length);
+                string typeFullName = Encoding.UTF8.GetString(typeInfo, 0, typeInfo.Length);
+                sourceType = System.Type.GetType(typeFullName);
+                offset += typeInfoSize;
+            }
 
             BaseTypeConverter converter = ConvertersSelector.SelectConverter(sourceType);
             if (converter is IEnumerableConverter)

--- a/src/BinaryFormatter/ConvertersSelector.cs
+++ b/src/BinaryFormatter/ConvertersSelector.cs
@@ -29,7 +29,8 @@ namespace BinaryFormatter
             [typeof(DateTime)] = new DatetimeConverter(),
             [typeof(byte[])] = new ByteArrayConverter(),
             [typeof(IEnumerable)] = new IEnumerableConverter(),
-            [typeof(object)] = new CustomObjectConverter()
+            [typeof(object)] = new CustomObjectConverter(),
+            [typeof(Guid)] = new GuidConverter()
         };
         private static readonly BaseTypeConverter NullConverter = new NullConverter();
 

--- a/src/BinaryFormatter/ConvertersSelector.cs
+++ b/src/BinaryFormatter/ConvertersSelector.cs
@@ -28,18 +28,27 @@ namespace BinaryFormatter
             [typeof(string)] = new StringConverter(),
             [typeof(DateTime)] = new DatetimeConverter(),
             [typeof(byte[])] = new ByteArrayConverter(),
-            [typeof(IEnumerable)] = new IEnumerableConverter()
+            [typeof(IEnumerable)] = new IEnumerableConverter(),
+            [typeof(object)] = new CustomObjectConverter()
         };
+        private static readonly BaseTypeConverter NullConverter = new NullConverter();
 
-        public BaseTypeConverter SelectConverter(object obj)
+        private ConvertersSelector()
         {
-            if(obj == null) return null;
+        }
+
+        public static BaseTypeConverter SelectConverter(object obj)
+        {
+            if (obj == null) return NullConverter;
+
             Type type = obj.GetType();
             return SelectConverter(type);
         }
 
-        public BaseTypeConverter SelectConverter(Type type)
+        public static BaseTypeConverter SelectConverter(Type type)
         {
+            if (type == null) return NullConverter;
+
             BaseTypeConverter converter;
             if (_converters.TryGetValue(type, out converter))
             {
@@ -55,11 +64,14 @@ namespace BinaryFormatter
                 }
             }
 
-            return null;
+            return ForSerializedType(SerializedType.CustomObject);
         }
 
-        public BaseTypeConverter ForSerializedType(SerializedType type)
+        public static BaseTypeConverter ForSerializedType(SerializedType type)
         {
+            if (type == SerializedType.Null)
+                return NullConverter;
+
             return _converters.First(x => x.Value.Type == type).Value;
         }
     }

--- a/src/BinaryFormatter/TypeConverter/BaseTypeConverter.cs
+++ b/src/BinaryFormatter/TypeConverter/BaseTypeConverter.cs
@@ -13,11 +13,7 @@ namespace BinaryFormatter.TypeConverter
             byte[] objectType = BitConverter.GetBytes((ushort)Type);
             stream.Write(objectType);
 
-            if (obj == null)
-            {
-
-            }
-            else
+            if (obj != null)
             {
                 byte[] typeInfo = Encoding.UTF8.GetBytes(obj.GetType().AssemblyQualifiedName);
                 stream.WriteWithLengthPrefix(typeInfo);

--- a/src/BinaryFormatter/TypeConverter/BoolConverter.cs
+++ b/src/BinaryFormatter/TypeConverter/BoolConverter.cs
@@ -13,7 +13,7 @@ namespace BinaryFormatter.TypeConverter
             stream.Write(data);
         }
 
-        protected override bool ProcessDeserialize(byte[] stream, ref int offset)
+        protected override bool ProcessDeserialize(byte[] stream, Type sourceType, ref int offset)
         {
             bool result = BitConverter.ToBoolean(stream, offset);
             return result;

--- a/src/BinaryFormatter/TypeConverter/ByteArrayConverter.cs
+++ b/src/BinaryFormatter/TypeConverter/ByteArrayConverter.cs
@@ -16,7 +16,7 @@ namespace BinaryFormatter.TypeConverter
             stream.WriteWithLengthPrefix(obj);
         }
 
-        protected override byte[] ProcessDeserialize(byte[] stream, ref int offset)
+        protected override byte[] ProcessDeserialize(byte[] stream, Type sourceType, ref int offset)
         {
             int size = BitConverter.ToInt32(stream, offset);
             offset += sizeof(int);

--- a/src/BinaryFormatter/TypeConverter/ByteConverter.cs
+++ b/src/BinaryFormatter/TypeConverter/ByteConverter.cs
@@ -13,7 +13,7 @@ namespace BinaryFormatter.TypeConverter
             stream.Write(data);
         }
 
-        protected override byte ProcessDeserialize(byte[] stream, ref int offset)
+        protected override byte ProcessDeserialize(byte[] stream, Type sourceType, ref int offset)
         {
             return (byte)BitConverter.ToUInt16(stream, offset);
         }

--- a/src/BinaryFormatter/TypeConverter/CharConverter.cs
+++ b/src/BinaryFormatter/TypeConverter/CharConverter.cs
@@ -13,7 +13,7 @@ namespace BinaryFormatter.TypeConverter
             stream.Write(data);
         }
 
-        protected override char ProcessDeserialize(byte[] stream, ref int offset)
+        protected override char ProcessDeserialize(byte[] stream, Type sourceType, ref int offset)
         {
             char result = BitConverter.ToChar(stream, offset);
             return result;

--- a/src/BinaryFormatter/TypeConverter/CustomObjectConverter.cs
+++ b/src/BinaryFormatter/TypeConverter/CustomObjectConverter.cs
@@ -82,13 +82,16 @@ namespace BinaryFormatter.TypeConverter
                 return;
             }
 
-            int typeInfoSize = BitConverter.ToInt32(stream, offset);
-            offset += sizeof(int);
-            byte[] typeInfo = new byte[typeInfoSize];
-            Array.Copy(stream, offset, typeInfo, 0, typeInfo.Length);
-            string typeFullName = Encoding.UTF8.GetString(typeInfo, 0, typeInfo.Length);
-            Type sourceType = System.Type.GetType(typeFullName);
-            offset += typeInfoSize;
+            if (!property.PropertyType.GetTypeInfo().IsBaseType())
+            {
+                int typeInfoSize = BitConverter.ToInt32(stream, offset);
+                offset += sizeof(int);
+                byte[] typeInfo = new byte[typeInfoSize];
+                Array.Copy(stream, offset, typeInfo, 0, typeInfo.Length);
+                string typeFullName = Encoding.UTF8.GetString(typeInfo, 0, typeInfo.Length);
+                Type sourceType = System.Type.GetType(typeFullName);
+                offset += typeInfoSize;
+            }
 
             BaseTypeConverter converter = ConvertersSelector.ForSerializedType(type);
             object data;            

--- a/src/BinaryFormatter/TypeConverter/CustomObjectConverter.cs
+++ b/src/BinaryFormatter/TypeConverter/CustomObjectConverter.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using BinaryFormatter.Types;
+using System.Collections.Generic;
+using System.Collections;
+using System.IO;
+using System.Text;
+using System.Reflection;
+using System.Linq;
+using BinaryFormatter.Utils;
+
+namespace BinaryFormatter.TypeConverter
+{
+    internal class CustomObjectConverter : BaseTypeConverter<object>
+    {
+        private static readonly List<string> excludedDlls = new List<string> { "CoreLib", "mscorlib" };
+        private int Size { get; set; }
+
+        protected override void WriteObjectToStream(object obj, Stream stream)
+        {
+            Type t = obj.GetType();
+
+            ICollection<PropertyInfo> properties = t.GetTypeInfo().GetAllProperties().ToArray();
+
+            foreach (PropertyInfo property in properties)
+            {
+                if (!property.CanWrite || property.GetMethod.IsStatic)
+                    continue;
+
+                object prop = property.GetValue(obj);
+                var converter = ConvertersSelector.SelectConverter(prop);
+                converter.Serialize(prop, stream);
+            }
+        }
+
+        protected override object ProcessDeserialize(byte[] stream, Type sourceType, ref int offset)
+        {
+            var instance = Activator.CreateInstance(sourceType);
+
+            foreach (PropertyInfo property in sourceType.GetTypeInfo().GetAllProperties())
+            {
+                if (!property.CanWrite)
+                    continue;
+
+                DeserializeProperty(property, ref instance, stream, ref offset);
+                if (offset == stream.Length)
+                    break;
+            }
+
+            return instance;
+        }
+
+        protected override int GetTypeSize()
+        {
+            return Size;
+        }
+
+        private void DeserializeProperty<T>(PropertyInfo property, ref T instance, byte[] stream, ref int offset)
+        {
+            if (!excludedDlls.Any(x => property.PropertyType.AssemblyQualifiedName.Contains(x)))
+            {
+                object propertyValue = Activator.CreateInstance(property.PropertyType);
+                property.SetValue(instance, propertyValue);
+                DeserializeObject(stream, ref propertyValue, ref offset);
+                return;
+            }
+
+            Type instanceType = typeof(T);
+            TypeInfo instanceTypeInfo = instanceType.GetTypeInfo();
+            SerializedType type = (SerializedType)BitConverter.ToInt16(stream, offset);
+            offset += sizeof(short);
+
+            int typeInfoSize = BitConverter.ToInt32(stream, offset);
+            offset += sizeof(int);
+            byte[] typeInfo = new byte[typeInfoSize];
+            Array.Copy(stream, offset, typeInfo, 0, typeInfo.Length);
+            string typeFullName = Encoding.UTF8.GetString(typeInfo, 0, typeInfo.Length);
+            Type sourceType = System.Type.GetType(typeFullName);
+            offset += typeInfoSize;
+
+            BaseTypeConverter converter = ConvertersSelector.ForSerializedType(type);
+            object data;
+            if (type == SerializedType.IEnumerable)
+            {
+                var prepearedData = converter.DeserializeToObject(stream, ref offset) as IEnumerable;
+
+                var prop = property;
+                var listType = typeof(List<>);
+                var genericArgs = prop.PropertyType.GenericTypeArguments;
+                var concreteType = listType.MakeGenericType(genericArgs);
+                data = Activator.CreateInstance(concreteType);
+                foreach (var item in prepearedData)
+                {
+                    ((IList)data).Add(item);
+                }
+            }
+            else
+            {
+                data = converter.DeserializeToObject(stream, ref offset);
+            }
+
+            if (instanceTypeInfo.IsValueType && !instanceTypeInfo.IsPrimitive)
+            {
+                object boxedInstance = (object)instance;
+                property.SetValue(boxedInstance, data, property.GetIndexParameters());
+                instance = (T)boxedInstance;
+            }
+            else
+            {
+                property.SetValue(instance, data, property.GetIndexParameters());
+            }
+        }
+
+        private void DeserializeObject<T>(byte[] stream, ref T instance, ref int offset)
+        {
+            foreach (PropertyInfo property in instance.GetType().GetTypeInfo().GetAllProperties())
+            {
+                if (!property.CanWrite)
+                    continue;
+
+                DeserializeProperty(property, ref instance, stream, ref offset);
+                if (offset == stream.Length)
+                    return;
+            }
+        }
+
+        public override SerializedType Type => SerializedType.CustomObject;
+    }
+}

--- a/src/BinaryFormatter/TypeConverter/DatetimeConverter.cs
+++ b/src/BinaryFormatter/TypeConverter/DatetimeConverter.cs
@@ -13,7 +13,7 @@ namespace BinaryFormatter.TypeConverter
             stream.Write(data);
         }
 
-        protected override DateTime ProcessDeserialize(byte[] stream, ref int offset)
+        protected override DateTime ProcessDeserialize(byte[] stream, Type sourceType, ref int offset)
         {
             long ticks = BitConverter.ToInt64(stream, offset);
             return DateTime.FromBinary(ticks);

--- a/src/BinaryFormatter/TypeConverter/DecimalConverter.cs
+++ b/src/BinaryFormatter/TypeConverter/DecimalConverter.cs
@@ -19,7 +19,7 @@ namespace BinaryFormatter.TypeConverter
             }
         }
 
-        protected override decimal ProcessDeserialize(byte[] stream, ref int offset)
+        protected override decimal ProcessDeserialize(byte[] stream, Type sourceType, ref int offset)
         {
             var bits = new int[4];
             for (int i = 0; i < 4; i++)

--- a/src/BinaryFormatter/TypeConverter/DoubleConverter.cs
+++ b/src/BinaryFormatter/TypeConverter/DoubleConverter.cs
@@ -13,7 +13,7 @@ namespace BinaryFormatter.TypeConverter
             stream.Write(data);
         }
 
-        protected override double ProcessDeserialize(byte[] stream, ref int offset)
+        protected override double ProcessDeserialize(byte[] stream, Type sourceType, ref int offset)
         {
             return BitConverter.ToDouble(stream, offset);
         }

--- a/src/BinaryFormatter/TypeConverter/FloatConverter.cs
+++ b/src/BinaryFormatter/TypeConverter/FloatConverter.cs
@@ -13,7 +13,7 @@ namespace BinaryFormatter.TypeConverter
             stream.Write(data);
         }
 
-        protected override float ProcessDeserialize(byte[] stream, ref int offset)
+        protected override float ProcessDeserialize(byte[] stream, Type sourceType, ref int offset)
         {
             return BitConverter.ToSingle(stream, offset);
         }

--- a/src/BinaryFormatter/TypeConverter/GuidConverter.cs
+++ b/src/BinaryFormatter/TypeConverter/GuidConverter.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.IO;
+using BinaryFormatter.Types;
+using BinaryFormatter.Utils;
+
+namespace BinaryFormatter.TypeConverter
+{
+    internal class GuidConverter : BaseTypeConverter<Guid>
+    {
+        protected override void WriteObjectToStream(Guid obj, Stream stream)
+        {
+            byte[] data = obj.ToByteArray();
+            stream.Write(data);
+        }
+
+        protected override Guid ProcessDeserialize(byte[] stream, Type sourceType, ref int offset)
+        {
+            byte[] guidData = new byte[16];
+            Array.Copy(stream, offset, guidData, 0, 16);
+
+            return new Guid(guidData);
+        }
+
+        protected override int GetTypeSize()
+        {
+            return sizeof (byte);
+        }
+
+        public override SerializedType Type => SerializedType.Guid;
+    }
+}

--- a/src/BinaryFormatter/TypeConverter/IEnumerableConverter.cs
+++ b/src/BinaryFormatter/TypeConverter/IEnumerableConverter.cs
@@ -50,8 +50,9 @@ namespace BinaryFormatter.TypeConverter
 
         protected override object ProcessDeserialize(byte[] stream, Type sourceType, ref int offset)
         {
+            int beforeOffset = offset;
             List<object> deserializedCollection = null;            
-
+            
             if (stream.Length > 0)
             {
                 BinaryConverter converter = new BinaryConverter();
@@ -80,7 +81,9 @@ namespace BinaryFormatter.TypeConverter
                 }
             }
 
-            Size = 0;
+            Size = offset - beforeOffset;
+            offset = beforeOffset;
+
             return deserializedCollection;
         }
 

--- a/src/BinaryFormatter/TypeConverter/IEnumerableConverter.cs
+++ b/src/BinaryFormatter/TypeConverter/IEnumerableConverter.cs
@@ -50,7 +50,7 @@ namespace BinaryFormatter.TypeConverter
 
         protected override object ProcessDeserialize(byte[] stream, Type sourceType, ref int offset)
         {
-            List<object> deserializedCollection = null;
+            List<object> deserializedCollection = null;            
 
             if (stream.Length > 0)
             {
@@ -62,19 +62,6 @@ namespace BinaryFormatter.TypeConverter
 
                 for (int i = 0; i < sizeCollection; i++)
                 {
-                    //int sizeTypeInfo = BitConverter.ToInt32(stream, offset);
-                    //offset += sizeof(int);
-                    //if (sizeTypeInfo == 0)
-                    //{
-                    //    continue;
-                    //}
-
-                    //byte[] typeInfo = new byte[sizeTypeInfo];
-                    //Array.Copy(stream, offset, typeInfo, 0, sizeTypeInfo);
-                    //string typeFullName = Encoding.UTF8.GetString(typeInfo, 0, sizeTypeInfo);
-                    //Type valueType = System.Type.GetType(typeFullName);
-                    //offset += sizeTypeInfo;
-
                     int sizeData = BitConverter.ToInt32(stream, offset);
                     offset += sizeof(int);
                     if (sizeData == 0)
@@ -83,12 +70,6 @@ namespace BinaryFormatter.TypeConverter
                     }
                     byte[] dataValue = new byte[sizeData];
                     Array.Copy(stream, offset, dataValue, 0, sizeData);
-
-                    //int typeInfoSize = BitConverter.ToInt32(dataValue, offset + sizeof(int));
-                    //byte[] typeInfo = new byte[typeInfoSize];
-                    //Array.Copy(stream, offset, typeInfo, 0, typeInfo.Length);
-                    //string typeFullName = Encoding.UTF8.GetString(typeInfo, 0, typeInfo.Length);
-                    //Type sourceType111 = System.Type.GetType(typeFullName);
 
                     MethodInfo method = typeof(BinaryConverter).GetRuntimeMethod("Deserialize", new System.Type[] { typeof(byte[]) });
                     method = method.MakeGenericMethod(typeof(object));                                        
@@ -99,6 +80,7 @@ namespace BinaryFormatter.TypeConverter
                 }
             }
 
+            Size = 0;
             return deserializedCollection;
         }
 

--- a/src/BinaryFormatter/TypeConverter/IEnumerableConverter.cs
+++ b/src/BinaryFormatter/TypeConverter/IEnumerableConverter.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Text;
 using System.Reflection;
 using BinaryFormatter.Utils;
+using System.Linq;
 
 namespace BinaryFormatter.TypeConverter
 {
@@ -16,7 +17,7 @@ namespace BinaryFormatter.TypeConverter
         protected override void WriteObjectToStream(object obj, Stream stream)
         {
             var objectAsCollection = (IList)obj;
-
+            
             byte[] collectionSize = BitConverter.GetBytes(objectAsCollection.Count);
             stream.Write(collectionSize);
 
@@ -73,7 +74,13 @@ namespace BinaryFormatter.TypeConverter
                     Array.Copy(stream, offset, dataValue, 0, sizeData);
 
                     MethodInfo method = typeof(BinaryConverter).GetRuntimeMethod("Deserialize", new System.Type[] { typeof(byte[]) });
-                    method = method.MakeGenericMethod(typeof(object));                                        
+                    if (sourceType.GenericTypeArguments.Length > 0)
+                    {
+                        method = method.MakeGenericMethod(sourceType.GenericTypeArguments);
+                    } else
+                    {
+                        method = method.MakeGenericMethod(typeof(object));
+                    }
                     object deserializeItem = method.Invoke(converter, new object[] { dataValue });
                     offset += sizeData;
 

--- a/src/BinaryFormatter/TypeConverter/IEnumerableConverter.cs
+++ b/src/BinaryFormatter/TypeConverter/IEnumerableConverter.cs
@@ -3,10 +3,8 @@ using BinaryFormatter.Types;
 using System.Collections.Generic;
 using System.Collections;
 using System.IO;
-using System.Text;
 using System.Reflection;
 using BinaryFormatter.Utils;
-using System.Linq;
 
 namespace BinaryFormatter.TypeConverter
 {

--- a/src/BinaryFormatter/TypeConverter/IntConverter.cs
+++ b/src/BinaryFormatter/TypeConverter/IntConverter.cs
@@ -13,7 +13,7 @@ namespace BinaryFormatter.TypeConverter
             stream.Write(data);
         }
 
-        protected override int ProcessDeserialize(byte[] stream, ref int offset)
+        protected override int ProcessDeserialize(byte[] stream, Type sourceType, ref int offset)
         {
             return BitConverter.ToInt32(stream, offset);
         }

--- a/src/BinaryFormatter/TypeConverter/LongConverter.cs
+++ b/src/BinaryFormatter/TypeConverter/LongConverter.cs
@@ -13,7 +13,7 @@ namespace BinaryFormatter.TypeConverter
             stream.Write(data);
         }
 
-        protected override long ProcessDeserialize(byte[] stream, ref int offset)
+        protected override long ProcessDeserialize(byte[] stream, Type sourceType, ref int offset)
         {
             return BitConverter.ToInt64(stream, offset);
         }

--- a/src/BinaryFormatter/TypeConverter/NullConverter.cs
+++ b/src/BinaryFormatter/TypeConverter/NullConverter.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using BinaryFormatter.Types;
+using System.Collections.Generic;
+using System.Collections;
+using System.IO;
+using System.Text;
+using System.Reflection;
+using System.Linq;
+using BinaryFormatter.Utils;
+
+namespace BinaryFormatter.TypeConverter
+{
+    internal class NullConverter : BaseTypeConverter<object>
+    {
+        private int Size { get; set; }
+
+        protected override void WriteObjectToStream(object obj, Stream stream)
+        {
+            stream.Write(new byte[0]);
+        }
+
+        protected override object ProcessDeserialize(byte[] stream, Type sourceType, ref int offset)
+        {
+            return null;
+        }
+
+        protected override int GetTypeSize()
+        {
+            return Size;
+        }
+
+        public override SerializedType Type => SerializedType.Null;
+    }
+}

--- a/src/BinaryFormatter/TypeConverter/SByteConverter.cs
+++ b/src/BinaryFormatter/TypeConverter/SByteConverter.cs
@@ -13,7 +13,7 @@ namespace BinaryFormatter.TypeConverter
             stream.Write(data);
         }
 
-        protected override sbyte ProcessDeserialize(byte[] stream, ref int offset)
+        protected override sbyte ProcessDeserialize(byte[] stream, Type sourceType, ref int offset)
         {
             return (sbyte)BitConverter.ToInt16(stream, offset);
         }

--- a/src/BinaryFormatter/TypeConverter/ShortConverter.cs
+++ b/src/BinaryFormatter/TypeConverter/ShortConverter.cs
@@ -13,7 +13,7 @@ namespace BinaryFormatter.TypeConverter
             stream.Write(data);
         }
 
-        protected override short ProcessDeserialize(byte[] stream, ref int offset)
+        protected override short ProcessDeserialize(byte[] stream, Type sourceType, ref int offset)
         {
             return BitConverter.ToInt16(stream, offset);
         }

--- a/src/BinaryFormatter/TypeConverter/StringConverter.cs
+++ b/src/BinaryFormatter/TypeConverter/StringConverter.cs
@@ -18,8 +18,9 @@ namespace BinaryFormatter.TypeConverter
             stream.WriteWithLengthPrefix(objBytes);
         }
 
-        protected override string ProcessDeserialize(byte[] stream, ref int offset)
+        protected override string ProcessDeserialize(byte[] stream, Type sourceType, ref int offset)
         {
+
             Size = BitConverter.ToInt32(stream, offset);
             offset += sizeof (int);
 

--- a/src/BinaryFormatter/TypeConverter/UIntConverter.cs
+++ b/src/BinaryFormatter/TypeConverter/UIntConverter.cs
@@ -13,7 +13,7 @@ namespace BinaryFormatter.TypeConverter
             stream.Write(data);
         }
 
-        protected override uint ProcessDeserialize(byte[] stream, ref int offset)
+        protected override uint ProcessDeserialize(byte[] stream, Type sourceType, ref int offset)
         {
             return BitConverter.ToUInt32(stream, offset);
         }

--- a/src/BinaryFormatter/TypeConverter/ULongConverter.cs
+++ b/src/BinaryFormatter/TypeConverter/ULongConverter.cs
@@ -13,7 +13,7 @@ namespace BinaryFormatter.TypeConverter
             stream.Write(data);
         }
 
-        protected override ulong ProcessDeserialize(byte[] stream, ref int offset)
+        protected override ulong ProcessDeserialize(byte[] stream, Type sourceType, ref int offset)
         {
             return BitConverter.ToUInt64(stream, offset);
         }

--- a/src/BinaryFormatter/TypeConverter/UshortConverter.cs
+++ b/src/BinaryFormatter/TypeConverter/UshortConverter.cs
@@ -13,7 +13,7 @@ namespace BinaryFormatter.TypeConverter
             stream.Write(data);
         }
 
-        protected override ushort ProcessDeserialize(byte[] stream, ref int offset)
+        protected override ushort ProcessDeserialize(byte[] stream, Type sourceType, ref int offset)
         {
             return BitConverter.ToUInt16(stream, offset);
         }

--- a/src/BinaryFormatter/Types/SerializedType.cs
+++ b/src/BinaryFormatter/Types/SerializedType.cs
@@ -1,7 +1,8 @@
 ﻿namespace BinaryFormatter.Types
 {
     internal enum SerializedType : ushort
-    {
+    {        
+        Null = 0,
         Byte = 1,
         Sbyte = 2,
         Char = 3,
@@ -18,6 +19,7 @@
         String = 14,
         Datetime = 15,
         ByteArray = 16,
-        IEnumerable = 17
+        IEnumerable = 17,
+        CustomObject = 99
     }
 }

--- a/src/BinaryFormatter/Types/SerializedType.cs
+++ b/src/BinaryFormatter/Types/SerializedType.cs
@@ -20,6 +20,7 @@
         Datetime = 15,
         ByteArray = 16,
         IEnumerable = 17,
+        Guid = 18,
         CustomObject = 99
     }
 }

--- a/src/BinaryFormatter/Utils/SerializedTypeExtensions.cs
+++ b/src/BinaryFormatter/Utils/SerializedTypeExtensions.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using BinaryFormatter.Types;
+
+namespace BinaryFormatter.Utils
+{
+    public static class SerializedTypeExtensions
+    {
+        internal static bool IsBaseType(this SerializedType serializedType)
+        {
+            return serializedType.GetBaseType() != null;
+        }
+
+        internal static Type GetBaseType(this SerializedType serializedType)
+        {
+            switch (serializedType)
+            {
+                case SerializedType.Bool:
+                    return typeof(bool);
+                case SerializedType.Byte:
+                    return typeof(byte);
+                case SerializedType.ByteArray:
+                    return typeof(byte[]);
+                case SerializedType.Char:
+                    return typeof(char);
+                case SerializedType.Datetime:
+                    return typeof(DateTime);
+                case SerializedType.Decimal:
+                    return typeof(decimal);
+                case SerializedType.Double:
+                    return typeof(double);
+                case SerializedType.Float:
+                    return typeof(float);
+                case SerializedType.Int:
+                    return typeof(int);
+                case SerializedType.Long:
+                    return typeof(long);
+                case SerializedType.Sbyte:
+                    return typeof(sbyte);
+                case SerializedType.Short:
+                    return typeof(short);
+                case SerializedType.String:
+                    return typeof(string);
+                case SerializedType.Uint:
+                    return typeof(uint);
+                case SerializedType.Ulong:
+                    return typeof(ulong);
+                case SerializedType.UShort:
+                    return typeof(ushort);
+                default:
+                    return null;
+            }
+        }
+    }
+}

--- a/src/BinaryFormatter/Utils/SerializedTypeExtensions.cs
+++ b/src/BinaryFormatter/Utils/SerializedTypeExtensions.cs
@@ -46,6 +46,8 @@ namespace BinaryFormatter.Utils
                     return typeof(ulong);
                 case SerializedType.UShort:
                     return typeof(ushort);
+                case SerializedType.Guid:
+                    return typeof(Guid);
                 default:
                     return null;
             }

--- a/src/BinaryFormatter/Utils/TypeInfoExtensions.cs
+++ b/src/BinaryFormatter/Utils/TypeInfoExtensions.cs
@@ -24,7 +24,8 @@ namespace BinaryFormatter.Utils
             typeof(decimal).GetTypeInfo(),
             typeof(string).GetTypeInfo(),
             typeof(DateTime).GetTypeInfo(),
-            typeof(byte[]).GetTypeInfo()
+            typeof(byte[]).GetTypeInfo(),
+            typeof(Guid).GetTypeInfo()
         };
 
         public static IEnumerable<ConstructorInfo> GetAllConstructors(this TypeInfo typeInfo)

--- a/src/BinaryFormatter/Utils/TypeInfoExtensions.cs
+++ b/src/BinaryFormatter/Utils/TypeInfoExtensions.cs
@@ -1,11 +1,32 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Linq;
 
 namespace BinaryFormatter.Utils
 {
     public static class TypeInfoExtensions
     {
+        private static List<TypeInfo> _baseTypes = new List<TypeInfo>()
+        {
+            typeof(byte).GetTypeInfo(),
+            typeof(sbyte).GetTypeInfo(),
+            typeof(char).GetTypeInfo(),
+            typeof(short).GetTypeInfo(),
+            typeof(ushort).GetTypeInfo(),
+            typeof(int).GetTypeInfo(),
+            typeof(uint).GetTypeInfo(),
+            typeof(long).GetTypeInfo(),
+            typeof(ulong).GetTypeInfo(),
+            typeof(float).GetTypeInfo(),
+            typeof(double).GetTypeInfo(),
+            typeof(bool).GetTypeInfo(),
+            typeof(decimal).GetTypeInfo(),
+            typeof(string).GetTypeInfo(),
+            typeof(DateTime).GetTypeInfo(),
+            typeof(byte[]).GetTypeInfo()
+        };
+
         public static IEnumerable<ConstructorInfo> GetAllConstructors(this TypeInfo typeInfo)
             => GetAll(typeInfo, ti => ti.DeclaredConstructors);
 
@@ -38,6 +59,11 @@ namespace BinaryFormatter.Utils
 
                 typeInfo = typeInfo.BaseType?.GetTypeInfo();
             }
+        }
+
+        public static bool IsBaseType(this TypeInfo typeInfo)
+        {
+            return _baseTypes.Where(bt => bt == typeInfo).Any();
         }
     }
 }

--- a/tests/BinaryFormatterTests/BinaryConverterTests.cs
+++ b/tests/BinaryFormatterTests/BinaryConverterTests.cs
@@ -201,6 +201,18 @@ namespace BinaryFormatterTests
         }
 
         [Fact]
+        public void CanSerialize_Null()
+        {
+            object value = null;
+
+            BinaryConverter converter = new BinaryConverter();
+            byte[] bytes = converter.Serialize(value);
+            object deserializedValue = converter.Deserialize<object>(bytes);
+
+            Assert.Equal(value, deserializedValue);
+        }
+
+        [Fact]
         public void CanSerialize_ByteArray()
         {
             byte[] value = Encoding.UTF8.GetBytes("lorem ipsum");

--- a/tests/BinaryFormatterTests/BinaryConverterTests.cs
+++ b/tests/BinaryFormatterTests/BinaryConverterTests.cs
@@ -237,5 +237,17 @@ namespace BinaryFormatterTests
 
             Assert.Equal(value, deserializedValue);
         }
+
+        [Fact]
+        public void CanSerialize_Guid()
+        {
+            Guid value = Guid.NewGuid();
+
+            BinaryConverter converter = new BinaryConverter();
+            byte[] bytes = converter.Serialize(value);
+            Guid deserializedValue = converter.Deserialize<Guid>(bytes);
+
+            Assert.Equal(value, deserializedValue);
+        }
     }
 }

--- a/tests/BinaryFormatterTests/ConvertersSelectorTests.cs
+++ b/tests/BinaryFormatterTests/ConvertersSelectorTests.cs
@@ -9,20 +9,18 @@ namespace BinaryFormatterTests
     public class ConvertersSelectorTests
     {
         [Fact]
-        public void ReturnsNull_WhenObjIsNull()
+        public void ReturnsNullConverter_WhenObjIsNull()
         {
-            var selector = new ConvertersSelector();
-            var converter = selector.SelectConverter((object)null);
-            Assert.Null(converter);
+            var converter = ConvertersSelector.SelectConverter(null);
+            Assert.True(converter is NullConverter);
         }
 
         [Theory]
         [MemberData(nameof(TestCases))]
         public void CorrectlyMapsTypesToConverters(object obj, Type expectedType)
         {
-            var selector = new ConvertersSelector();
-            var fromType = selector.SelectConverter(obj);
-            var fromSerializedType = selector.ForSerializedType(fromType.Type);
+            var fromType = ConvertersSelector.SelectConverter(obj);
+            var fromSerializedType = ConvertersSelector.ForSerializedType(fromType.Type);
 
             Assert.Equal(fromType, fromSerializedType);
             Assert.Equal(fromType.GetType(), expectedType);

--- a/tests/BinaryFormatterTests/TypeConverter/BaseTypeConverterTests.cs
+++ b/tests/BinaryFormatterTests/TypeConverter/BaseTypeConverterTests.cs
@@ -12,22 +12,6 @@ namespace BinaryFormatterTests.TypeConverter
     {
         public const string Message = "Lorem ipsum";
         
-        [Fact]
-        public void ThrowsWhenObjIsNull()
-        {
-            Fake fake = new Fake();
-
-            Assert.ThrowsAny<ArgumentNullException>(() => fake.Serialize(null, new MemoryStream()));
-        }
-
-        [Fact]
-        public void ThrowsWhenObjIsNullWithCasting()
-        {
-            Fake fake = new Fake();
-
-            Assert.ThrowsAny<ArgumentNullException>(() => fake.Serialize((object)null, new MemoryStream()));
-        }
-
         internal class Fake : BaseTypeConverter<string>
         {
             protected override int GetTypeSize()
@@ -41,7 +25,7 @@ namespace BinaryFormatterTests.TypeConverter
                 stream.Write(data);
             }
 
-            protected override string ProcessDeserialize(byte[] stream, ref int offset)
+            protected override string ProcessDeserialize(byte[] stream, Type sourceType, ref int offset)
             {
                 int size = BitConverter.ToInt32(stream, offset);
                 offset += sizeof (int);

--- a/tests/BinaryFormatterTests/TypeConverter/CustomObjectConverterTests.cs
+++ b/tests/BinaryFormatterTests/TypeConverter/CustomObjectConverterTests.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using BinaryFormatter;
+using Xunit;
+
+namespace BinaryFormatterTests.TypeConverter
+{
+    public class CustomObjectConverterTests
+    {
+        [Fact]
+        public void CanSerializeAndDeserialize_SimpleObject()
+        {
+            var converter = new BinaryConverter();
+
+            SimpleObject simpleObject = new SimpleObject() { Name = "John", Age = 50 };
+
+            byte[] bytesSimpleObject = converter.Serialize(simpleObject);
+            var valueFromBytesSimpleObject = converter.Deserialize<SimpleObject>(bytesSimpleObject);
+            Assert.Equal(valueFromBytesSimpleObject.Name, simpleObject.Name);
+            Assert.Equal(valueFromBytesSimpleObject.Age, simpleObject.Age);
+        }
+
+        [Fact (Skip = "Work in progress...")]
+        public void CanSerializeAndDeserialize_ComplexObject()
+        {
+            var converter = new BinaryConverter();
+
+            ComplexObject serializableRow = new ComplexObject();
+            serializableRow.MasterRow = new ComplexObjectRow();
+            //serializableRow.MasterRow.Data = new[] {
+            //    new ComplexObjectColumn
+            //    {
+            //        Name = "Key",
+            //        Value = "12345"
+            //    },
+            //    new ComplexObjectColumn
+            //    {
+            //        Name = "TestMasterName0",
+            //        Value = "TestMasterValue0"
+            //    }
+            //};
+            //serializableRow.DetailRows = new[] 
+            //{
+            //    new ComplexObjectRow
+            //    {
+            //        Data = new[] 
+            //        {
+            //            new ComplexObjectColumn { Name = "TestDetailName0", Value = "TestDetailValue0" },
+            //            new ComplexObjectColumn { Name = "TestDetailName1", Value = "TestDetailValue1" }
+            //        }
+            //    }
+            //};
+
+            var rowBytes = converter.Serialize(serializableRow);
+            var row = converter.Deserialize<ComplexObject>(rowBytes);
+        }
+
+        class SimpleObject
+        {
+            public string Name { get; set; }
+            public int Age { get; set; }
+        }
+
+        public class ComplexObject
+        {
+            public ComplexObjectRow MasterRow { get; set; }
+            public IEnumerable<ComplexObjectRow> DetailRows { get; set; }
+        }
+
+        public class ComplexObjectColumn
+        {
+            public string Name { get; set; }
+            public string Value { get; set; }
+        }
+
+        public class ComplexObjectRow
+        {
+            public IEnumerable<ComplexObjectColumn> Data { get; set; }
+        }
+    }
+}

--- a/tests/BinaryFormatterTests/TypeConverter/CustomObjectConverterTests.cs
+++ b/tests/BinaryFormatterTests/TypeConverter/CustomObjectConverterTests.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
-using System.Text;
 using BinaryFormatter;
 using Xunit;
 

--- a/tests/BinaryFormatterTests/TypeConverter/CustomObjectConverterTests.cs
+++ b/tests/BinaryFormatterTests/TypeConverter/CustomObjectConverterTests.cs
@@ -22,39 +22,58 @@ namespace BinaryFormatterTests.TypeConverter
             Assert.Equal(valueFromBytesSimpleObject.Age, simpleObject.Age);
         }
 
-        [Fact (Skip = "Work in progress...")]
+        [Fact]
         public void CanSerializeAndDeserialize_ComplexObject()
         {
             var converter = new BinaryConverter();
 
             ComplexObject serializableRow = new ComplexObject();
             serializableRow.MasterRow = new ComplexObjectRow();
-            //serializableRow.MasterRow.Data = new[] {
-            //    new ComplexObjectColumn
-            //    {
-            //        Name = "Key",
-            //        Value = "12345"
-            //    },
-            //    new ComplexObjectColumn
-            //    {
-            //        Name = "TestMasterName0",
-            //        Value = "TestMasterValue0"
-            //    }
-            //};
-            //serializableRow.DetailRows = new[] 
-            //{
-            //    new ComplexObjectRow
-            //    {
-            //        Data = new[] 
-            //        {
-            //            new ComplexObjectColumn { Name = "TestDetailName0", Value = "TestDetailValue0" },
-            //            new ComplexObjectColumn { Name = "TestDetailName1", Value = "TestDetailValue1" }
-            //        }
-            //    }
-            //};
+            serializableRow.MasterRow.Data = new[] {
+                new ComplexObjectColumn
+                {
+                    Name = "Key",
+                    Value = "12345"
+                },
+                new ComplexObjectColumn
+                {
+                    Name = "TestMasterName0",
+                    Value = "TestMasterValue0"
+                }
+            };
+            serializableRow.DetailRows = new[]
+            {
+                new ComplexObjectRow
+                {
+                    Data = new[]
+                    {
+                        new ComplexObjectColumn { Name = "TestDetailName0", Value = "TestDetailValue0" },
+                        new ComplexObjectColumn { Name = "TestDetailName1", Value = "TestDetailValue1" }
+                    }
+                }
+            };
 
             var rowBytes = converter.Serialize(serializableRow);
-            var row = converter.Deserialize<ComplexObject>(rowBytes);
+            var deserializedRow = converter.Deserialize<ComplexObject>(rowBytes);
+
+            // TODO Find solution for easiest way to compare of two object
+
+            var serializableRow_MasterRow_Data = (IList)serializableRow.MasterRow.Data;
+            var deserializedRow_MasterRow_Data = (IList)deserializedRow.MasterRow.Data;
+            Assert.Equal(serializableRow_MasterRow_Data.Count, ((IList)deserializedRow.MasterRow.Data).Count);
+            Assert.Equal((serializableRow_MasterRow_Data[0] as ComplexObjectColumn).Name, (deserializedRow_MasterRow_Data[0] as ComplexObjectColumn).Name);
+            Assert.Equal((serializableRow_MasterRow_Data[0] as ComplexObjectColumn).Value, (deserializedRow_MasterRow_Data[0] as ComplexObjectColumn).Value);
+            Assert.Equal((serializableRow_MasterRow_Data[1] as ComplexObjectColumn).Name, (deserializedRow_MasterRow_Data[1] as ComplexObjectColumn).Name);
+            Assert.Equal((serializableRow_MasterRow_Data[1] as ComplexObjectColumn).Value, (deserializedRow_MasterRow_Data[1] as ComplexObjectColumn).Value);
+
+            var serializableRow_DetailRows = (IList)serializableRow.DetailRows;
+            var derializableRow_DetailRows = (IList)deserializedRow.DetailRows;
+            Assert.Equal(serializableRow_DetailRows.Count, derializableRow_DetailRows.Count);
+            Assert.Equal(((IList)(serializableRow_DetailRows[0] as ComplexObjectRow).Data).Count, ((IList)(((IList)deserializedRow.DetailRows)[0] as ComplexObjectRow).Data).Count);
+            Assert.Equal((((IList)(serializableRow_DetailRows[0] as ComplexObjectRow).Data)[0] as ComplexObjectColumn).Name, (((IList)(derializableRow_DetailRows[0] as ComplexObjectRow).Data)[0] as ComplexObjectColumn).Name);
+            Assert.Equal((((IList)(serializableRow_DetailRows[0] as ComplexObjectRow).Data)[0] as ComplexObjectColumn).Value, (((IList)(derializableRow_DetailRows[0] as ComplexObjectRow).Data)[0] as ComplexObjectColumn).Value);
+            Assert.Equal((((IList)(serializableRow_DetailRows[0] as ComplexObjectRow).Data)[1] as ComplexObjectColumn).Name, (((IList)(derializableRow_DetailRows[0] as ComplexObjectRow).Data)[1] as ComplexObjectColumn).Name);
+            Assert.Equal((((IList)(serializableRow_DetailRows[0] as ComplexObjectRow).Data)[1] as ComplexObjectColumn).Value, (((IList)(derializableRow_DetailRows[0] as ComplexObjectRow).Data)[1] as ComplexObjectColumn).Value);
         }
 
         class SimpleObject

--- a/tests/BinaryFormatterTests/TypeConverter/GuidConverterTests.cs
+++ b/tests/BinaryFormatterTests/TypeConverter/GuidConverterTests.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Xunit;
+
+namespace BinaryFormatterTests.TypeConverter
+{
+    public class GuidConverterTests : ConverterTest<Guid>
+    {
+        public override Guid Value => Guid.Parse("af26f890-9202-46f2-ac31-f5e7abc098a3");
+
+        [Fact]
+        public void CanSerializeAndDeserialize()
+        {
+            RunTest();
+        }
+    }
+}

--- a/tests/BinaryFormatterTests/TypeConverter/IEnumerableConverterTests.cs
+++ b/tests/BinaryFormatterTests/TypeConverter/IEnumerableConverterTests.cs
@@ -32,6 +32,7 @@ namespace BinaryFormatterTests.TypeConverter
             simpleCollection.Add(uint.MaxValue);
             simpleCollection.Add(ulong.MaxValue);
             simpleCollection.Add(ushort.MaxValue);
+            simpleCollection.Add(Guid.NewGuid());
 
             byte[] bytesSimpleCollection = converter.Serialize(simpleCollection);
             var valueFromBytesSimpleCollection = converter.Deserialize<List<object>>(bytesSimpleCollection);

--- a/tests/BinaryFormatterTests/TypeConverter/NullConverterTests.cs
+++ b/tests/BinaryFormatterTests/TypeConverter/NullConverterTests.cs
@@ -1,0 +1,15 @@
+﻿using Xunit;
+
+namespace BinaryFormatterTests.TypeConverter
+{
+    public class NullConverterTests : ConverterTest<object>
+    {
+        public override object Value => null;
+
+        [Fact]
+        public void CanSerializeAndDeserialize()
+        {
+            RunTest();
+        }
+    }
+}

--- a/tests/BinaryFormatterTests/Utils/SerializedTypeExtensionsTests.cs
+++ b/tests/BinaryFormatterTests/Utils/SerializedTypeExtensionsTests.cs
@@ -1,0 +1,34 @@
+﻿using BinaryFormatter.Utils;
+using Xunit;
+using BinaryFormatter.Types;
+
+namespace BinaryFormatterTests.Utils
+{
+    public class SerializedTypeExtensionsTests
+    {
+        [Fact]
+        public void IsBaseType()
+        {
+            Assert.True(SerializedType.Bool.IsBaseType());
+            Assert.True(SerializedType.Byte.IsBaseType());
+            Assert.True(SerializedType.ByteArray.IsBaseType());
+            Assert.True(SerializedType.Char.IsBaseType());            
+            Assert.True(SerializedType.Datetime.IsBaseType());
+            Assert.True(SerializedType.Decimal.IsBaseType());
+            Assert.True(SerializedType.Double.IsBaseType());
+            Assert.True(SerializedType.Float.IsBaseType());            
+            Assert.True(SerializedType.Int.IsBaseType());
+            Assert.True(SerializedType.Long.IsBaseType());            
+            Assert.True(SerializedType.Sbyte.IsBaseType());
+            Assert.True(SerializedType.Short.IsBaseType());
+            Assert.True(SerializedType.String.IsBaseType());
+            Assert.True(SerializedType.Uint.IsBaseType());
+            Assert.True(SerializedType.Ulong.IsBaseType());
+            Assert.True(SerializedType.UShort.IsBaseType());
+
+            Assert.False(SerializedType.CustomObject.IsBaseType());
+            Assert.False(SerializedType.IEnumerable.IsBaseType());
+            Assert.False(SerializedType.Null.IsBaseType());
+        }
+    }
+}

--- a/tests/BinaryFormatterTests/Utils/TypeInfoExtensionsTests.cs
+++ b/tests/BinaryFormatterTests/Utils/TypeInfoExtensionsTests.cs
@@ -96,5 +96,25 @@ namespace BinaryFormatterTests.Utils
 
             Assert.Equal(allProperties.Count(), 2);
         }
+
+        [Fact]
+        public void IsBaseType()
+        {
+            Assert.True((typeof(byte)).GetTypeInfo().IsBaseType());
+            Assert.True((typeof(sbyte)).GetTypeInfo().IsBaseType());
+            Assert.True((typeof(char)).GetTypeInfo().IsBaseType());
+            Assert.True((typeof(short)).GetTypeInfo().IsBaseType());
+            Assert.True((typeof(ushort)).GetTypeInfo().IsBaseType());
+            Assert.True((typeof(int)).GetTypeInfo().IsBaseType());
+            Assert.True((typeof(uint)).GetTypeInfo().IsBaseType());
+            Assert.True((typeof(long)).GetTypeInfo().IsBaseType());
+            Assert.True((typeof(ulong)).GetTypeInfo().IsBaseType());
+            Assert.True((typeof(float)).GetTypeInfo().IsBaseType());
+            Assert.True((typeof(double)).GetTypeInfo().IsBaseType());
+            Assert.True((typeof(decimal)).GetTypeInfo().IsBaseType());
+            Assert.True((typeof(string)).GetTypeInfo().IsBaseType());
+            Assert.True((typeof(DateTime)).GetTypeInfo().IsBaseType());
+            Assert.True((typeof(byte[])).GetTypeInfo().IsBaseType());            
+        }
     }
 }

--- a/tests/BinaryFormatterTests/WhenWorkingWith_Classes.cs
+++ b/tests/BinaryFormatterTests/WhenWorkingWith_Classes.cs
@@ -1,7 +1,5 @@
 ﻿using BinaryFormatter;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using Xunit;
 
 namespace BinaryFormatterTests

--- a/tests/BinaryFormatterTests/WhenWorkingWith_Classes.cs
+++ b/tests/BinaryFormatterTests/WhenWorkingWith_Classes.cs
@@ -15,83 +15,19 @@ namespace BinaryFormatterTests
             public string String { get; set; }
         }
 
-        abstract class WithVirtualProperties
+        class WithReadonlyProperties
         {
-            protected static readonly List<WithVirtualProperties_Element> _elements = new List<WithVirtualProperties_Element>();
-
-            protected static IReadOnlyCollection<WithVirtualProperties_Element> AllElements => _elements;
-
-            public static IReadOnlyCollection<WithVirtualProperties_Group> AllGroups
-            {
-                get
-                {
-                    return _elements.Select(gr => gr.Group).Distinct().ToList();
-                }
-            }
-
             public string Name { get; set; }
-
-            protected WithVirtualProperties()
+            public DateTime BirthDay { get; set; }
+            public int Age
             {
-            }
-
-            protected WithVirtualProperties(string Name)
-            {
-                this.Name = Name;
-            }
-
-            public override string ToString()
-            {
-                return Name;
-            }
-        }
-
-        class WithVirtualProperties_Element : WithVirtualProperties
-        {
-            public WithVirtualProperties_Group Group { get; set; }
-
-            public WithVirtualProperties_Element()
-            {
-            }
-
-            public WithVirtualProperties_Element(string Name, WithVirtualProperties_Group Group):base(Name)
-            {
-                this.Group = Group;
-                _elements.Add(this);
-            }
-
-            public virtual IEnumerable<WithVirtualProperties_Group> Groups {
                 get
                 {
-                    return AllElements
-                        .Where(el => el == this)
-                        .Select(gr => gr.Group)
-                        .Distinct()
-                        .ToList();
+                    return DateTime.Now.Year - BirthDay.Year;
                 }
-            }
+            }               
         }
 
-        class WithVirtualProperties_Group : WithVirtualProperties
-        {
-            public WithVirtualProperties_Group()
-            {
-            }
-
-            public WithVirtualProperties_Group(string Name) : base(Name)
-            {
-            }
-
-            public virtual IEnumerable<WithVirtualProperties_Element> Elements {
-                get {
-
-                    return AllElements
-                        .Where(el => el.Group == this)
-                        .Select(el => el)
-                        .ToList();
-                }
-            }
-        }
 
         [Fact]
         public void CanWorkWith_ClassesWithoutCustomCtor_WithProperties_WithPublicSetter()
@@ -109,29 +45,21 @@ namespace BinaryFormatterTests
         }
 
         [Fact]
-        public void CanWorkWith_Classes_WithVirtualProperties()
+        public void CanWorkWith_Classes_WithReadonlyProperties()
         {
-            for (int iGroup = 1; iGroup <= 5; iGroup++)
+            var before = new WithReadonlyProperties()
             {
-                string groupName = string.Format("Group {0}", iGroup);
-                WithVirtualProperties_Group currentGroup = new WithVirtualProperties_Group(groupName);
-
-                for (int iElement = 1; iElement <= 5; iElement++)
-                {
-                    string nameElement = string.Format("Element {0}-{1}", iGroup, iElement);
-                    WithVirtualProperties_Element currentElement = new WithVirtualProperties_Element(nameElement, currentGroup);
-                }
-            }
+                Name = "John",
+                BirthDay = DateTime.Now.AddYears(-50)
+            };
 
             var formatter = new BinaryConverter();
+            byte[] data = formatter.Serialize(before);
+            var after = formatter.Deserialize<WithReadonlyProperties>(data);
 
-            foreach (WithVirtualProperties_Group group in WithVirtualProperties.AllGroups)
-            {
-                byte[] data = formatter.Serialize(group);
-                WithVirtualProperties_Group after = formatter.Deserialize<WithVirtualProperties_Group>(data);
-
-                Assert.Equal(group.Name, after.Name);
-            }
+            Assert.Equal(before.Name, after.Name);
+            Assert.Equal(before.BirthDay, after.BirthDay);
+            Assert.Equal(before.Age, after.Age);
         }
     }
 }


### PR DESCRIPTION
- #26 Improved current format of binary data for serialization / deserialization values
- #19 Added support for NULL values
- Added CustomObject converter for working with classes and structures.
- #48 Fixed for complex objects
- Added unit tests for new features and improvements.
- Using checking for writable properties instead of checking for virtual properties. Updated unit tests for this.

This is first step for 2.0 release. After code review I will working on the next PR.
New format of binary serialization / deserialization based on the next structure:
- Internall type
- Type info size
- Type info
- Data size
- Data

For NULL values stored only internall type. In the future I will disable type info block for primitive types and none valued types.

Also we need a detailed description of the binary data format. I can do it after the release 2.0.